### PR TITLE
Add CSV parser

### DIFF
--- a/safe_locking_service/utils/csv_helper.py
+++ b/safe_locking_service/utils/csv_helper.py
@@ -1,8 +1,10 @@
 import csv
-from typing import IO
+from typing import IO, Generator
 
 
-def parse(stream: IO, skip_header: bool = True):
+def parse(
+    stream: IO[str], skip_header: bool = True
+) -> Generator[list[str], None, None]:
     """
     Reads a CSV stream (file-like object) and yields each row one at a time, optionally skipping the header.
     """

--- a/safe_locking_service/utils/csv_helper.py
+++ b/safe_locking_service/utils/csv_helper.py
@@ -1,7 +1,8 @@
 import csv
+from typing import IO
 
 
-def parse(stream, skip_header: bool = True):
+def parse(stream: IO, skip_header: bool = True):
     """
     Reads a CSV stream (file-like object) and yields each row one at a time, optionally skipping the header.
     """

--- a/safe_locking_service/utils/csv_helper.py
+++ b/safe_locking_service/utils/csv_helper.py
@@ -1,0 +1,15 @@
+import csv
+
+
+def parse(stream, skip_header: bool = True):
+    """
+    Reads a CSV stream (file-like object) and yields each row one at a time, optionally skipping the header.
+    """
+    reader = csv.reader(stream, delimiter=",", quotechar="|")
+    # Skips the header
+    if skip_header:
+        next(reader, None)
+
+    # Read and print each row
+    for row in reader:
+        yield row

--- a/safe_locking_service/utils/tests/test_csv.py
+++ b/safe_locking_service/utils/tests/test_csv.py
@@ -10,18 +10,18 @@ class CSVTestCase(unittest.TestCase):
         with StringIO(csv_content) as file:
             result = list(csv_helper.parse(file))
 
-            assert result == [["John", "30"], ["Jane", "25"]]
+            self.assertEqual(result, [["John", "30"], ["Jane", "25"]])
 
     def test_no_rows(self):
         csv_content = "name,age"
         with StringIO(csv_content) as file:
             result = list(csv_helper.parse(file))
 
-            assert result == []
+            self.assertEqual(result, [])
 
     def test_no_header_skip(self):
         csv_content = "name,age\nJohn,30\nJane,25"
         with StringIO(csv_content) as file:
             result = list(csv_helper.parse(file, skip_header=False))
 
-            assert result == [["name", "age"], ["John", "30"], ["Jane", "25"]]
+            self.assertEqual(result, [["name", "age"], ["John", "30"], ["Jane", "25"]])

--- a/safe_locking_service/utils/tests/test_csv.py
+++ b/safe_locking_service/utils/tests/test_csv.py
@@ -1,0 +1,27 @@
+import unittest
+from io import StringIO
+
+from .. import csv_helper
+
+
+class CSVTestCase(unittest.TestCase):
+    def test_parsing(self):
+        csv_content = "name,age\nJohn,30\nJane,25"
+        with StringIO(csv_content) as file:
+            result = list(csv_helper.parse(file))
+
+            assert result == [["John", "30"], ["Jane", "25"]]
+
+    def test_no_rows(self):
+        csv_content = "name,age"
+        with StringIO(csv_content) as file:
+            result = list(csv_helper.parse(file))
+
+            assert result == []
+
+    def test_no_header_skip(self):
+        csv_content = "name,age\nJohn,30\nJane,25"
+        with StringIO(csv_content) as file:
+            result = list(csv_helper.parse(file, skip_header=False))
+
+            assert result == [["name", "age"], ["John", "30"], ["Jane", "25"]]


### PR DESCRIPTION
Part of #81

- Introduces a utility function `csv_helper.parse` to parse CSV files.
- This utility function takes a file stream and yields a tuple representing the row items
