### PR TITLE
Use campaigns path prefix in config.urls

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -47,7 +47,7 @@ urlpatterns_v1 = [
         include("safe_locking_service.locking_events.urls", namespace="locking_events"),
     ),
     path(
-        "",
+        "campaigns/",
         include("safe_locking_service.campaigns.urls", namespace="locking_campaigns"),
     ),
 ]

--- a/safe_locking_service/campaigns/urls.py
+++ b/safe_locking_service/campaigns/urls.py
@@ -5,9 +5,9 @@ from . import views
 app_name = "campaigns"
 
 urlpatterns = [
-    path("campaigns/", views.CampaignsView.as_view(), name="list-campaigns"),
+    path("", views.CampaignsView.as_view(), name="list-campaigns"),
     path(
-        "campaigns/<str:resource_id>/",
+        "<str:resource_id>/",
         views.RetrieveCampaignView.as_view(),
         name="retrieve-campaign",
     ),


### PR DESCRIPTION
- Moves the `campaigns` prefix from the urls specified under the Campaigns App to the root configuration (as all routes under the campaigns URL should start with that prefix).