### PR TITLE
Add admin action to upload period data

### DIFF
--- a/safe_locking_service/campaigns/admin.py
+++ b/safe_locking_service/campaigns/admin.py
@@ -1,4 +1,6 @@
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.http import HttpResponseRedirect
+from django.urls import reverse
 
 from .models import Activity, ActivityMetadata, Campaign, Period
 
@@ -15,6 +17,21 @@ class CampaignAdmin(admin.ModelAdmin):
     )
 
 
+@admin.action(description="Upload data for selected period")
+def upload_period_data_action(modeladmin, request, queryset):
+    selected_periods = queryset.count()
+    if selected_periods != 1:
+        messages.error(
+            request, "Please select exactly one item to perform this action."
+        )
+        return
+    redirect_url = (
+        reverse("v1:campaigns:activities_upload")
+        + f"?period_slug={queryset.first().slug}"
+    )
+    return HttpResponseRedirect(redirect_url)
+
+
 @admin.register(Period)
 class PeriodAdmin(admin.ModelAdmin):
     list_display = (
@@ -29,6 +46,8 @@ class PeriodAdmin(admin.ModelAdmin):
         "start_date",
         "end_date",
     )
+
+    actions = [upload_period_data_action]
 
 
 @admin.register(Activity)

--- a/safe_locking_service/campaigns/forms.py
+++ b/safe_locking_service/campaigns/forms.py
@@ -13,7 +13,7 @@ class FileUploadForm(forms.Form):
     def __init__(self, *args, **kwargs):
         period_slug = kwargs.pop("period_slug", None)
         super().__init__(*args, **kwargs)
-        if period_slug is not None:
+        if period_slug:
             self.fields["period"].queryset = Period.objects.filter(slug=period_slug)
             self.fields["period"].empty_label = None
         else:

--- a/safe_locking_service/campaigns/forms.py
+++ b/safe_locking_service/campaigns/forms.py
@@ -5,7 +5,16 @@ from .models import Period
 
 class FileUploadForm(forms.Form):
     period = forms.ModelChoiceField(
-        queryset=Period.objects.order_by("-start_date"),
+        queryset=Period.objects.none(),
         empty_label="Choose a Campaign Period",
     )
     file = forms.FileField()
+
+    def __init__(self, *args, **kwargs):
+        period_slug = kwargs.pop("period_slug", None)
+        super().__init__(*args, **kwargs)
+        if period_slug is not None:
+            self.fields["period"].queryset = Period.objects.filter(slug=period_slug)
+            self.fields["period"].empty_label = None
+        else:
+            self.fields["period"].queryset = Period.objects.order_by("-start_date")

--- a/safe_locking_service/campaigns/views.py
+++ b/safe_locking_service/campaigns/views.py
@@ -6,12 +6,12 @@ from typing import IO, Optional
 from django.contrib.admin.views.decorators import staff_member_required
 from django.db.models import F, Max, Sum, Window
 from django.db.models.functions import Rank
-from django.http import HttpRequest
-from django.http import HttpResponse
+from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
+
 from rest_framework import status
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.response import Response
@@ -22,6 +22,7 @@ from safe_locking_service.campaigns.serializers import (
     CampaignSerializer,
 )
 from safe_locking_service.locking_events.pagination import SmallPagination
+
 from . import tasks
 from .forms import FileUploadForm
 from .models import Activity, Campaign, Period
@@ -150,7 +151,7 @@ class CampaignLeaderBoardView(ListAPIView):
                 total_campaign_points=Sum("total_points"),
                 total_campaign_boosted_points=Sum("total_boosted_points"),
                 last_boost=F("total_campaign_boosted_points")
-                           / F("total_campaign_points"),
+                / F("total_campaign_points"),
             )
             .order_by(F("total_campaign_boosted_points").desc())
             .annotate(


### PR DESCRIPTION
- Allows uploading data for a given period via an admin action. [^1]
- Only one period is allowed to be selected. An error is shown to the user if more periods are selected.
- The view triggered on the action is tied to `GET /api/v1/campaigns/upload/?period_slug=<period_slug>`
  * If the view is loaded with a `period_slug` query parameter, the picker will only have that entry selected. [^2]
  * If no query parameter is provided, any period can be selected. [^3]




[^1]: <img width="472" alt="image" src="https://github.com/safe-global/safe-locking-service/assets/3332770/723d29a6-ba7e-4116-972b-781dccee5f42">

[^2]:<img width="727" alt="image" src="https://github.com/safe-global/safe-locking-service/assets/3332770/ed9a4b22-fa31-4cca-8b68-4e9f200cb4a1">

[^3]:<img width="724" alt="image" src="https://github.com/safe-global/safe-locking-service/assets/3332770/9c415771-73eb-43b9-9ea2-c9888219a174">

