### PR TITLE
Validate Campaign date ranges

### DIFF
--- a/safe_locking_service/campaigns/models.py
+++ b/safe_locking_service/campaigns/models.py
@@ -38,6 +38,19 @@ class Campaign(models.Model):
     start_date = models.DateTimeField(null=True, blank=True)
     end_date = models.DateTimeField(null=True, blank=True)
 
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super(Campaign, self).save()
+
+    def clean(self):
+        if self.start_date and self.end_date and self.start_date > self.end_date:
+            raise ValidationError(
+                {
+                    "start_date": "Start date cannot be after end date",
+                    "end_date": "End date cannot be before start date",
+                }
+            )
+
     def __str__(self):
         return f"Campaign {self.uuid} {self.name}"
 

--- a/safe_locking_service/campaigns/tests/factories.py
+++ b/safe_locking_service/campaigns/tests/factories.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from random import randrange
 
 from django.utils import timezone
@@ -18,7 +19,7 @@ class CampaignFactory(DjangoModelFactory):
     name = FuzzyText(length=randrange(51))
     description = Faker("bs")
     start_date = LazyFunction(timezone.now)
-    end_date = LazyFunction(timezone.now)
+    end_date = LazyFunction(lambda: timezone.now() + timedelta(days=1))
 
 
 class PeriodFactory(DjangoModelFactory):

--- a/safe_locking_service/campaigns/tests/test_models.py
+++ b/safe_locking_service/campaigns/tests/test_models.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ValidationError
-from django.db import DataError, IntegrityError
+from django.db import IntegrityError
 from django.test import TestCase
 
 from faker import Faker
@@ -19,15 +19,14 @@ class CampaignsTestCase(TestCase):
         self.assertEqual(str(campaign), f"Campaign {campaign.uuid} {campaign.name}")
 
     def test_campaign_with_null_name(self):
-        campaign = CampaignFactory.build(name=None)
-
-        self.assertRaises(IntegrityError, campaign.save)
+        with self.assertRaises(ValidationError):
+            CampaignFactory(name=None)
 
     def test_campaign_with_name_longer_than_50_characters(self):
         invalid_name = fake.pystr(min_chars=51, max_chars=255)
-        campaign = CampaignFactory.build(name=invalid_name)
 
-        self.assertRaises(DataError, campaign.save)
+        with self.assertRaises(ValidationError):
+            CampaignFactory(name=invalid_name)
 
     def test_campaign_with_null_description(self):
         campaign = CampaignFactory.build(description=None)
@@ -43,6 +42,18 @@ class CampaignsTestCase(TestCase):
         campaign = CampaignFactory.build(end_date=None)
 
         campaign.save()
+
+    def test_allows_same_dates(self):
+        date = fake.date_time()
+
+        CampaignFactory(end_date=date, start_date=date)
+
+    def test_does_not_allow_end_date_before_start_date(self):
+        start_date = fake.future_datetime()
+        end_date = fake.past_datetime()
+
+        with self.assertRaises(ValidationError):
+            CampaignFactory(end_date=end_date, start_date=start_date)
 
 
 class PeriodTestCase(TestCase):


### PR DESCRIPTION
- Validates that the date time ranges are valid – the `start_date` must be at the same time or before `end_date`.