### PR TITLE
Use fixed length name in CampaignFactory

### DIFF
--- a/safe_locking_service/campaigns/tests/factories.py
+++ b/safe_locking_service/campaigns/tests/factories.py
@@ -1,7 +1,10 @@
+from random import randrange
+
 from django.utils import timezone
 
 from factory import Faker, LazyFunction, SubFactory
 from factory.django import DjangoModelFactory
+from factory.fuzzy import FuzzyText
 
 from ..models import ActivityMetadata, Campaign, Period
 
@@ -10,7 +13,7 @@ class CampaignFactory(DjangoModelFactory):
     class Meta:
         model = Campaign
 
-    name = Faker("catch_phrase")
+    name = FuzzyText(length=randrange(51))
     description = Faker("bs")
     start_date = LazyFunction(timezone.now)
     end_date = LazyFunction(timezone.now)


### PR DESCRIPTION
The `CampaignFactory` could potentially generate strings longer than 50 characters (thus introducing some flakiness when running the tests).

This sets the range to a string of a random length between [0, 51[.