### PR TITLE
Fix uuid validation in url route

### DIFF
--- a/safe_locking_service/campaigns/urls.py
+++ b/safe_locking_service/campaigns/urls.py
@@ -9,17 +9,17 @@ urlpatterns = [
     path("", views.CampaignsView.as_view(), name="list-campaigns"),
     path("upload/", upload_activities_view, name="activities_upload"),
     path(
-        "<str:resource_id>/",
+        "<uuid:resource_id>/",
         views.RetrieveCampaignView.as_view(),
         name="retrieve-campaign",
     ),
     path(
-        "<str:resource_id>/leaderboard/",
+        "<uuid:resource_id>/leaderboard/",
         views.CampaignLeaderBoardView.as_view(),
         name="leaderboard-campaign",
     ),
     path(
-        "<str:resource_id>/leaderboard/<str:address>/",
+        "<uuid:resource_id>/leaderboard/<str:address>/",
         views.CampaignLeaderBoardPositionView.as_view(),
         name="leaderboard-campaign-position",
     ),


### PR DESCRIPTION
## Description
Invalid `UUID` was causing 500 error in several endpoints, this PR enable validation of the `UUID` in the url route.