### PR TITLE
Improve CSV error log

### DIFF
--- a/safe_locking_service/campaigns/tests/test_views.py
+++ b/safe_locking_service/campaigns/tests/test_views.py
@@ -237,7 +237,7 @@ class TestActivitiesUploadView(TestCase):
         self.assertEqual(200, response.status_code)
         self.assertTrue(
             response.context.get("error_message").startswith(
-                "Invalid CSV format: File does not include one or more of the following headers:"
+                "Error processing CSV: File does not include one or more of the following headers:"
             )
         )
 

--- a/safe_locking_service/campaigns/views.py
+++ b/safe_locking_service/campaigns/views.py
@@ -108,7 +108,7 @@ def upload_activities_view(request: HttpRequest) -> HttpResponse:
                 return redirect(reverse("admin:index"))
             except Exception as e:
                 logger.warning(e)
-                error_message = f"Invalid CSV format: {e}"
+                error_message = f"Error processing CSV: {e}"
                 return render(
                     request,
                     "activities/upload.html",


### PR DESCRIPTION
- Errors might not be related to the format of the CSV file so a more generic error message is used (the details of the error message are still shown to the user)