### PR TITLE
Fix Period validation issue

### DIFF
--- a/safe_locking_service/campaigns/models.py
+++ b/safe_locking_service/campaigns/models.py
@@ -64,9 +64,9 @@ class Period(models.Model):
     end_date = models.DateField()
 
     def save(self, *args, **kwargs):
-        self.full_clean()
         if not self.slug:
             self.slug = slugify(f"{self.start_date}-{self.end_date}")
+        self.full_clean()
         super(Period, self).save(*args, **kwargs)
 
     def clean(self):


### PR DESCRIPTION
We should call `full_clean()` after setting the `slug` field. If validate before setting the `slug` field then the the `save()` will fail.