### PR TITLE
Add Black as a dev dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 24.4.2
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -1,6 +1,7 @@
 """
 Store gunicorn variables in this file, so they can be read by Django
 """
+
 import os
 
 gunicorn_request_timeout = os.environ.get("WEB_WORKER_TIMEOUT", 60)

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -13,6 +13,7 @@ middleware here, or combine a Django application with an application of another
 framework.
 
 """
+
 import os
 import sys
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 -r requirements-test.txt
+black==24.4.2
 flake8
 ipdb
 ipython


### PR DESCRIPTION
- Adds `black` (https://black.readthedocs.io/) as a dev dependency.
- `black` is a code formatter that is executed in the pipeline (configured via `.pre-commit`). Since the dependency is already something that is executed in the CI environment, we should also make it available as a dependency of the project.
