### PR TITLE
Removes docker compose version property

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
   ganache:
     image: trufflesuite/ganache:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 volumes:
   nginx-shared:
 


### PR DESCRIPTION
The `version` property is only informative and is now considered obsolete.

See https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete
