### PR TITLE
Add view to retrieve period data

### DIFF
--- a/safe_locking_service/campaigns/serializers.py
+++ b/safe_locking_service/campaigns/serializers.py
@@ -55,3 +55,18 @@ class CampaignLeaderBoardSerializer(serializers.Serializer):
 
     def get_total_points(self, obj: Dict):
         return obj["total_campaign_points"]
+
+
+class PeriodAddressSerializer(serializers.Serializer):
+    start_date = serializers.SerializerMethodField()
+    end_date = serializers.SerializerMethodField()
+    holder = serializers.CharField(source="address")
+    boost = serializers.CharField()
+    total_points = serializers.CharField()
+    total_boosted_points = serializers.CharField()
+
+    def get_start_date(self, obj):
+        return obj.period.start_date
+
+    def get_end_date(self, obj):
+        return obj.period.end_date

--- a/safe_locking_service/campaigns/serializers.py
+++ b/safe_locking_service/campaigns/serializers.py
@@ -58,15 +58,9 @@ class CampaignLeaderBoardSerializer(serializers.Serializer):
 
 
 class PeriodAddressSerializer(serializers.Serializer):
-    start_date = serializers.SerializerMethodField()
-    end_date = serializers.SerializerMethodField()
+    start_date = serializers.DateField(source="period.start_date")
+    end_date = serializers.DateField(source="period.end_date")
     holder = serializers.CharField(source="address")
     boost = serializers.CharField()
     total_points = serializers.CharField()
     total_boosted_points = serializers.CharField()
-
-    def get_start_date(self, obj):
-        return obj.period.start_date
-
-    def get_end_date(self, obj):
-        return obj.period.end_date

--- a/safe_locking_service/campaigns/serializers.py
+++ b/safe_locking_service/campaigns/serializers.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 from rest_framework import serializers
 
+from gnosis.eth.django.serializers import EthereumAddressField
 from gnosis.eth.utils import fast_to_checksum_address
 
 from safe_locking_service.campaigns.models import Campaign
@@ -60,7 +61,7 @@ class CampaignLeaderBoardSerializer(serializers.Serializer):
 class PeriodAddressSerializer(serializers.Serializer):
     start_date = serializers.DateField(source="period.start_date")
     end_date = serializers.DateField(source="period.end_date")
-    holder = serializers.CharField(source="address")
+    holder = EthereumAddressField(source="address")
     boost = serializers.CharField()
     total_points = serializers.CharField()
     total_boosted_points = serializers.CharField()

--- a/safe_locking_service/campaigns/urls.py
+++ b/safe_locking_service/campaigns/urls.py
@@ -1,13 +1,18 @@
 from django.urls import path
 
 from . import views
-from .views import upload_activities_view
+from .views import GetAddressPeriodsView, upload_activities_view
 
 app_name = "campaigns"
 
 urlpatterns = [
     path("", views.CampaignsView.as_view(), name="list-campaigns"),
     path("upload/", upload_activities_view, name="activities_upload"),
+    path(
+        "<uuid:resource_id>/activities/",
+        GetAddressPeriodsView.as_view(),
+        name="get-address-periods",
+    ),
     path(
         "<uuid:resource_id>/",
         views.RetrieveCampaignView.as_view(),

--- a/safe_locking_service/campaigns/views.py
+++ b/safe_locking_service/campaigns/views.py
@@ -217,6 +217,7 @@ class GetAddressPeriodsView(ListAPIView):
 
         return queryset.select_related("period").order_by("-period__start_date")
 
+    @method_decorator(cache_page(1 * 60))  # 1 minute
     def get(self, *args, **kwargs):
         queryset = self.get_queryset()
         serializer = self.serializer_class(queryset, many=True)


### PR DESCRIPTION
### What was wrong? 👾

Closes #131 

### How was it fixed? 🎯

- Adds an endpoint to retrieve the activity information for a specific `Campaign`
- This endpoint can be used to filter the Activities done by a specific `holder` - by setting the `holder` address as the query parameter

The endpoint is as follows:

```javascript
GET /api/v1/campaigns/<uuid:resource_id>/activities/?holder=<address>

{
  "count": <number>,
  "next": <url>, // nullable
  "previous": <url>,  // nullable
  "results": [
    {
      "startDate": <string>, // date string e.g.: 2024-05-20
      "endDate": <string>, // date string e.g.: 2024-05-20
      "holder": <string>, // Holder's address
      "boost": <string>, // decimal string
      "totalPoints": <string>, // big number string
      "totalBoostedPoints": <string> // decimal string
    }
  ]
}
```