### PR TITLE
Explicitly create user defined network

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -68,7 +68,8 @@ jobs:
     steps:
     - name: Setup and run ganache
       run: |
-        docker run --detach --publish 8545:8545 --network-alias ganache -e DOCKER=true trufflesuite/ganache:latest --defaultBalanceEther 10000 --gasLimit 10000000 -a 30 --chain.chainId 1337 --chain.networkId 1337 -d
+        docker network create ganache
+        docker run --detach --publish 8545:8545 --network ganache -e DOCKER=true trufflesuite/ganache:latest --defaultBalanceEther 10000 --gasLimit 10000000 -a 30 --chain.chainId 1337 --chain.networkId 1337 -d
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5


### PR DESCRIPTION
Explicitly create a user-defined (`ganache`) network before using it.

See https://github.com/docker/cli/blob/v26.1.3/docs/deprecated.md