### PR TITLE
Use ModelSerializer for CampaignSerializer

### DIFF
--- a/safe_locking_service/campaigns/serializers.py
+++ b/safe_locking_service/campaigns/serializers.py
@@ -14,22 +14,24 @@ class ActivityMetadataSerializer(serializers.Serializer):
     max_points = serializers.IntegerField()
 
 
-class CampaignSerializer(serializers.Serializer):
-    resource_id = serializers.SerializerMethodField()
-    name = serializers.CharField()
-    description = serializers.CharField()
-    start_date = serializers.DateTimeField()
-    end_date = serializers.DateTimeField()
-    last_updated = serializers.SerializerMethodField()
+class CampaignSerializer(serializers.ModelSerializer):
+    resource_id = serializers.UUIDField(source="uuid")
+    last_updated = serializers.CharField()
     activities_metadata = ActivityMetadataSerializer(
         many=True, source="activity_metadata"
     )
 
-    def get_resource_id(self, obj: Campaign):
-        return obj.uuid
-
-    def get_last_updated(self, obj: Campaign):
-        return obj.last_updated
+    class Meta:
+        model = Campaign
+        fields = [
+            "resource_id",
+            "name",
+            "description",
+            "start_date",
+            "end_date",
+            "last_updated",
+            "activities_metadata",
+        ]
 
 
 class CampaignLeaderBoardSerializer(serializers.Serializer):


### PR DESCRIPTION
- The `CampaignSerializer` now extends the `ModelSerializer` instead of the base `Serializer` class.
- This is usually preferable for serialisers which take a model class as the base for serialisation as it automatically generates a set of fields to be used based on the model and will generate the respective validators for the serialiser.