### PR TITLE
Enable file serving in development

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.conf.urls import include
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.http import HttpResponse
 from django.urls import path, re_path
@@ -52,12 +53,15 @@ urlpatterns_v1 = [
     ),
 ]
 
-urlpatterns = swagger_urlpatterns + [
-    path(settings.ADMIN_URL, admin.site.urls),
-    path("api/v1/", include((urlpatterns_v1, "v1"))),
-    path("check/", lambda request: HttpResponse("Ok"), name="check"),
-]
-
+urlpatterns = (
+    swagger_urlpatterns
+    + [
+        path(settings.ADMIN_URL, admin.site.urls),
+        path("api/v1/", include((urlpatterns_v1, "v1"))),
+        path("check/", lambda request: HttpResponse("Ok"), name="check"),
+    ]
+    + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+)
 
 if settings.DEBUG:
     # This allows the error pages to be debugged during development, just visit


### PR DESCRIPTION
Enables static file serving when in debug mode (e.g., while developing locally).

This allows for media that is uploaded to the service locally, to be available on a public path.
