### PR TITLE
Add S3 Storage backend integration

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -369,6 +369,31 @@ LOGGING = {
     },
 }
 
+DEFAULT_STORAGE_BACKEND = env("DEFAULT_STORAGE_BACKEND", default="local")
+
+if DEFAULT_STORAGE_BACKEND == "s3":
+    storage_backend = {
+        "BACKEND": "storages.backends.s3.S3Storage",
+    }
+    # For additional settings see https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#settings
+    AWS_STORAGE_BUCKET_NAME = env("AWS_STORAGE_BUCKET_NAME")
+    AWS_ACCESS_KEY_ID = env("AWS_ACCESS_KEY_ID")
+    AWS_SECRET_ACCESS_KEY = env("AWS_SECRET_ACCESS_KEY")
+    # Set this to specify a custom domain for constructed URLs.
+    AWS_S3_CUSTOM_DOMAIN = env("AWS_S3_CUSTOM_DOMAIN")
+
+else:
+    storage_backend = {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    }
+
+STORAGES = {
+    "default": storage_backend,
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+
 SWAGGER_SETTINGS = {
     "SECURITY_DEFINITIONS": {
         "api_key": {"type": "apiKey", "in": "header", "name": "Authorization"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 asgiref==3.7.2
+boto3==1.34.127
 cachetools==5.3.3
 celery==5.4.0
 Django==5.0.6
@@ -11,6 +12,7 @@ django-debug-toolbar-force
 django-environ==0.11.2
 django-extensions==3.2.3
 django-redis==5.4.0
+django-storages[s3]==1.14.3
 djangorestframework==3.15.1
 djangorestframework-camel-case==1.4.2
 docutils==0.21.2


### PR DESCRIPTION
- Adds S3 as a Storage Backend (functionality provided via `django-storages[s3]`)
- Reads `DEFAULT_STORAGE_BACKEND` from the local environment for deciding which configuration to use.
  * If the value is `s3`, then `storages.backends.s3.S3Storage` will be used as a backend storage.
  * If any other value is provided, then `django.core.files.storage.FileSystemStorage` will be used (Django's default).
- Setting the `DEFAULT_STORAGE_BACKEND` to `s3` requires setting the AWS related configurations (service won't start if those are not set).