### PR TITLE
Optimise Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,42 @@
-.cache
-.dockerignore
+# Git / GitHub related files
 .gitignore
 .git
 .github
-.env
-.pylintrc
-__pycache__
-*.pyc
-*.egg-info
+
+# IDE / editor related files
 .idea/
 .vscode
+
+# Docker related files
+docker-compose*.yml
+Dockerfile
+.dockerignore
+
+# Python bytecode files
+__pycache__/
+*.pyc
+
+# Python cache and configuration files
+.cache
+.mypy_cache
+.pytest_cache
+
+# Python linting and test configuration
+.pylintrc
+.pre-commit-config.yaml
+
+# Python egg-info
+*.egg-info
+
+# Python virtual environments
+venv/
+env/
+ENV/
+
+# Other specific files to ignore
+.env
+.gitattributes
+run_tests.sh
+requirements-dev.txt
+requirements-test.txt
+README.md

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,8 +1,4 @@
-FROM python:3.11-slim
-
-ARG APP_HOME=/app
-WORKDIR ${APP_HOME}
-ENV PYTHONUNBUFFERED=1
+FROM python:3.11-slim as builder
 
 # https://eth-hash.readthedocs.io/en/latest/quickstart.html#specify-backend-by-environment-variable
 # `pysha3` is way faster than `pycryptodome` for CPython
@@ -10,27 +6,37 @@ ENV ETH_HASH_BACKEND=pysha3
 
 COPY requirements.txt ./
 RUN set -ex \
-	&& buildDeps=" \
-		build-essential \
-        git \
-		libssl-dev \
-        libpq-dev \
-		" \
     && apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends $buildDeps tmux postgresql-client \
+    && apt-get install -y gcc libpq-dev \
     && pip install -U --no-cache-dir wheel setuptools pip \
     && pip install --no-cache-dir -r requirements.txt \
-    && apt-get purge -y --auto-remove $buildDeps \
     && rm -rf /var/lib/apt/lists/*
 
+
+# Production image
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Force the stdout and stderr streams to be unbuffered. This option has no effect on the stdin stream.
+# https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUNBUFFERED
+ENV PYTHONUNBUFFERED 1
+ENV ETH_HASH_BACKEND=pysha3
+
+COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY . /app/
+
 # /nginx mount point must be created before so it doesn't have root permissions
-# ${APP_HOME} root folder will not be updated by COPY --chown, so permissions need to be adjusted
+# /app root folder will not be updated by COPY --chown, so permissions need to be adjusted
 RUN groupadd -g 999 python && \
     useradd -u 999 -r -g python python && \
     mkdir -p /nginx && \
-    chown -R python:python /nginx ${APP_HOME}
-COPY --chown=python:python . .
+    chown -R python:python /nginx /app
+
+RUN apt-get update \
+    && apt-get install -y libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Use numeric ids so kubernetes identifies the user correctly
 USER 999:999


### PR DESCRIPTION
- The Docker file now uses a multistage build setup which is split into two different stages:
  * `builder` stage
  * final/production stage
- The `builder` stage uses the `requirements.txt` to download and install the required dependencies for the project.
  * This stage needs `gcc` and `libpq-dev` to build the dependencies of the project
  * This stage removed the following dependencies: `build-essential`, `git`, `libssl-dev` as they are not required.
- The final/production stage uses the dependencies that were built in the `builder` stage by copying those to the respective local folders of the new final image.
  * This stage copies all the contents of the project into the `/app` folder.
  * Additionally, it also installs `libpq-dev` as this is a required runtime dependency.

Other considerations:
- The setting `PYTHONDONTWRITEBYTECODE` was considered. This would tell Python to not create `pyc` files which would save around 6MB. However, in a multiprocess container (with Gunicorn), each process might need to incur on generating that bytecode again. Using more storage in this case seems therefore, more appropriate.