### PR TITLE
Fix config for local environment

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,11 @@
+PYTHONPATH=/app/
+DEBUG=0
+DJANGO_SETTINGS_MODULE=config.settings.local
+DJANGO_SECRET_KEY=t3st-s3cr3t#-!k3y
+ETH_HASH_BACKEND=pysha3
+REDIS_URL=redis://redis:6379/0
+DATABASE_URL=psql://postgres:postgres@db:5432/postgres
+CELERY_BROKER_URL=amqp://guest:guest@rabbitmq/
+CSRF_TRUSTED_ORIGINS="http://localhost:8000"
+ETHEREUM_MAINNET_NODE=https://ethereum.publicnode.com
+ETHEREUM_NODE_URL=http://ganache:8545

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -47,3 +47,8 @@ INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]
 # CELERY
 # ------------------------------------------------------------------------------
 CELERY_RESULT_BACKEND = env("CELERY_RESULT_BACKEND", default=REDIS_URL)
+
+# SECURITY
+# ------------------------------------------------------------------------------
+# https://docs.djangoproject.com/en/3.2/ref/settings/#csrf-trusted-origins
+CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])


### PR DESCRIPTION
It is currently not possible to access the Django admin without updating the CSRF_TRUSTED_ORIGINS in the local configuration.

It is also necessary to update some names in the local docker urls.
